### PR TITLE
add sendMessage to the FCMProvider protocol so it can be mocked in tests

### DIFF
--- a/Sources/FCM/FCM.swift
+++ b/Sources/FCM/FCM.swift
@@ -5,7 +5,9 @@ import Crypto
 
 // MARK: Service
 
-public protocol FCMProvider: Service {}
+public protocol FCMProvider: Service {
+    func sendMessage(_ client: Client, message: FCMMessageDefault) throws -> Future<String>
+}
 
 // MARK: Engine
 


### PR DESCRIPTION
Hello !

This PR declare the `sendMessage` in the `FCMProvider` protocol so we can mock it by using the `config.prefer` mechanism of Vapor 3 like this:

```swift 
services.register(FCMMock.self)
config.prefer(FCMMock.self, for: FCMProvider.self)
```