### PR TITLE
Fix apple payload datamodel access

### DIFF
--- a/Sources/FCM/FCMApnsConfig/FCMApnsAlert.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsAlert.swift
@@ -2,37 +2,37 @@ public struct FCMApnsAlert: Codable {
     /// The title of the notification.
     /// Apple Watch displays this string in the short look notification interface.
     /// Specify a string that is quickly understood by the user.
-    var title: String?
+    public var title: String?
     /// Additional information that explains the purpose of the notification.
-    var subtitle: String?
+    public var subtitle: String?
     /// The content of the alert message.
-    var body: String?
+    public var body: String?
     /// The name of the launch image file to display.
     /// If the user chooses to launch your app,
     /// the contents of the specified image or storyboard file are displayed instead of your app's normal launch image.
-    var launchImage: String?
+    public var launchImage: String?
     /// The key for a localized title string.
     /// Specify this key instead of the title key to retrieve the title from your app’s Localizable.strings files.
     /// The value must contain the name of a key in your strings file.
-    var titleLocKey: String?
+    public var titleLocKey: String?
     /// An array of strings containing replacement values for variables in your title string.
     /// Each %@ character in the string specified by the title-loc-key is replaced by a value from this array.
     /// The first item in the array replaces the first instance of the %@ character in the string, the second item replaces the second instance, and so on.
-    var titleLocArgs: [String]?
+    public var titleLocArgs: [String]?
     /// The key for a localized subtitle string.
     /// Use this key, instead of the subtitle key, to retrieve the subtitle from your app's Localizable.strings file.
     /// The value must contain the name of a key in your strings file.
-    var subtitleLocKey: String?
+    public var subtitleLocKey: String?
     /// An array of strings containing replacement values for variables in your title string.
     /// Each %@ character in the string specified by subtitle-loc-key is replaced by a value from this array.
     /// The first item in the array replaces the first instance of the %@ character in the string, the second item replaces the second instance, and so on.
-    var subtitleLocArgs: [String]?
+    public var subtitleLocArgs: [String]?
     ///A key to an alert-message string in a Localizable.strings file for the current localization (which is set by the user’s language preference).
     /// The key string can be formatted with %@ and %n$@ specifiers to take the variables specified in the loc-args array.
     /// See Localizing the Content of Your Remote Notifications for more information.
-    var locKey: String?
+    public var locKey: String?
     ///Variable string values to appear in place of the format specifiers in loc-key. See Localizing the Content of Your Remote Notifications for more information.
-    var locArgs: [String]?
+    public var locArgs: [String]?
 
     enum CodingKeys: String, CodingKey {
         case title

--- a/Sources/FCM/FCMApnsConfig/FCMApnsAlertOrString.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsAlertOrString.swift
@@ -1,6 +1,6 @@
 /// Internal helper for different alert payload types
-enum FCMApnsAlertOrString: Codable {
-    init(from decoder: Decoder) throws {
+public enum FCMApnsAlertOrString: Codable {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let string = try? container.decode(String.self) {
             self = .string(string)
@@ -10,7 +10,7 @@ enum FCMApnsAlertOrString: Codable {
         }
     }
 
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {
         case let .alert(alert):
@@ -28,6 +28,20 @@ enum FCMApnsAlertOrString: Codable {
     static func fromRaw(_ v: String?) -> FCMApnsAlertOrString? {
         guard let v = v else { return nil }
         return .string(v)
+    }
+    
+    public var alertPayload: FCMApnsAlert? {
+        if case let .alert(payload) = self {
+            return payload
+        }
+        return nil
+    }
+    
+    public var alertMessage: String? {
+        if case let .string(message) = self {
+            return message
+        }
+        return nil
     }
 
     /// A container for alerts

--- a/Sources/FCM/FCMApnsConfig/FCMApnsApsObject.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsApsObject.swift
@@ -4,10 +4,10 @@ public class FCMApnsApsObject: Codable {
     /// The information for displaying an alert.
     /// A dictionary is recommended.
     /// If you specify a string, the alert displays your string as the body text.
-    var alert: FCMApnsAlertOrString?
+    public var alert: FCMApnsAlertOrString?
     
     /// The number to display in a badge on your app’s icon. Specify 0 to remove the current badge, if any.
-    var badge: Int?
+    public var badge: Int?
     
     /// The name of a sound file in your app’s main bundle
     /// or in the Library/Sounds folder of your app’s container directory.
@@ -16,27 +16,27 @@ public class FCMApnsApsObject: Codable {
     /// For critical alerts, use the sound dictionary instead.
     /// For information about how to prepare sounds, see UNNotificationSound.
     /// UNNotificationSound: https://developer.apple.com/documentation/usernotifications/unnotificationsound
-    var sound: String? // NOTE: Advanced Sounds are not implemented yet
+    public var sound: String? // NOTE: Advanced Sounds are not implemented yet
     
     /// An app-specific identifier for grouping related notifications.
     /// This value corresponds to the threadIdentifier property in the UNNotificationContent object.
-    var threadId: String?
+    public var threadId: String?
     
     /// The notification’s type.
     /// This string must correspond to the identifier
     /// of one of the UNNotificationCategory objects you register at launch time.
-    var category: String?
+    public var category: String?
     
     /// The background notification flag.
     /// To perform a silent background update,
     /// specify the value 1
     /// and don't include the alert, badge, or sound keys in your payload.
-    var contentAvailable: Int?
+    public var contentAvailable: Int?
     
     /// The notification service app extension flag.
     /// If the value is 1, the system passes the notification to your notification service app extension before delivery.
     /// Use your extension to modify the notification’s content.
-    var mutableContent: Int?
+    public var mutableContent: Int?
 
     enum CodingKeys: String, CodingKey {
         case alert


### PR DESCRIPTION
In order to test my model properties, I need to access the properties values of the APNs data models.

As they are already public in the Android side, I imagine this is not a deal breaker to homogenize it on the Apple side?

I just have a few doubts on the final result:

1. should we make them accessible only in readonly mode with a `private(set)` (I didn't add it since Android is fully public)
2. To make this work, I had to make `FCMApnsAlertOrString` public to make Swift compiler happy in `FCMApnsApsObject` (aka: _can't set property public because type used in not public yadiyada_)
3. Not sure on the naming of the `FCMApnsAlertOrString` helpers to access the enum associated values: `alertPayload`/`alertMessage` or `asPayload`/`asMessage` or `asPayload`/`asString`

at call site it looks like this right now:

```swift
iosConfig?.payload.aps.alert?.alertPayload?.titleLocArgs
```

so maybe it would look better like this:

```swift
Config?.payload.aps.alert?.asPayload?.titleLocArgs
```
🤔 

What do you think?

Thanks in advance!