### PR TITLE
Make config datamodel equatable and rename FCMApnsAlertOrString helpers

### DIFF
--- a/Sources/FCM/FCMAndroidConfig/FCMAndroidConfig.swift
+++ b/Sources/FCM/FCMAndroidConfig/FCMAndroidConfig.swift
@@ -1,4 +1,4 @@
-public struct FCMAndroidConfig: Codable {
+public struct FCMAndroidConfig: Codable, Equatable {
     /// An identifier of a group of messages that can be collapsed, so that only the last message gets sent when delivery can be resumed.
     /// A maximum of 4 different collapse keys is allowed at any given time.
     public var collapse_key: String?

--- a/Sources/FCM/FCMAndroidConfig/FCMAndroidMessagePriority.swift
+++ b/Sources/FCM/FCMAndroidConfig/FCMAndroidMessagePriority.swift
@@ -1,4 +1,4 @@
-public enum FCMAndroidMessagePriority: String, Codable {
+public enum FCMAndroidMessagePriority: String, Codable, Equatable {
     /// Default priority for data messages.
     /// Normal priority messages won't open network connections on a sleeping device,
     /// and their delivery may be delayed to conserve the battery.

--- a/Sources/FCM/FCMAndroidConfig/FCMAndroidNotification.swift
+++ b/Sources/FCM/FCMAndroidConfig/FCMAndroidNotification.swift
@@ -1,4 +1,4 @@
-public struct FCMAndroidNotification: Codable {
+public struct FCMAndroidNotification: Codable, Equatable {
     /// The notification's title.
     /// If present, it will override FCMNotification.title.
     public var title: String?

--- a/Sources/FCM/FCMApnsConfig/FCMApnsAlert.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsAlert.swift
@@ -1,4 +1,4 @@
-public struct FCMApnsAlert: Codable {
+public struct FCMApnsAlert: Codable, Equatable {
     /// The title of the notification.
     /// Apple Watch displays this string in the short look notification interface.
     /// Specify a string that is quickly understood by the user.

--- a/Sources/FCM/FCMApnsConfig/FCMApnsAlertOrString.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsAlertOrString.swift
@@ -30,14 +30,14 @@ public enum FCMApnsAlertOrString: Codable, Equatable {
         return .string(v)
     }
     
-    public var alertPayload: FCMApnsAlert? {
+    public var asPayload: FCMApnsAlert? {
         if case let .alert(payload) = self {
             return payload
         }
         return nil
     }
     
-    public var alertMessage: String? {
+    public var asMessage: String? {
         if case let .string(message) = self {
             return message
         }

--- a/Sources/FCM/FCMApnsConfig/FCMApnsAlertOrString.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsAlertOrString.swift
@@ -1,5 +1,5 @@
 /// Internal helper for different alert payload types
-public enum FCMApnsAlertOrString: Codable {
+public enum FCMApnsAlertOrString: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let string = try? container.decode(String.self) {

--- a/Sources/FCM/FCMApnsConfig/FCMApnsApsObject.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsApsObject.swift
@@ -1,6 +1,6 @@
 // The following struct is based on
 // https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification
-public class FCMApnsApsObject: Codable {
+public struct FCMApnsApsObject: Codable, Equatable {
     /// The information for displaying an alert.
     /// A dictionary is recommended.
     /// If you specify a string, the alert displays your string as the body text.
@@ -79,7 +79,7 @@ public class FCMApnsApsObject: Codable {
         return FCMApnsApsObject(alertString: nil, sound: "default")
     }
     
-    public convenience init(alertString: String?,
+    public init(alertString: String?,
                             badge: Int? = nil,
                             sound: String?,
                             contentAvailable: Bool? = nil,
@@ -95,7 +95,7 @@ public class FCMApnsApsObject: Codable {
                                  mutableContent: mutableContent))
     }
     
-    public convenience init(alert: FCMApnsAlert? = nil,
+    public init(alert: FCMApnsAlert? = nil,
                             badge: Int? = nil,
                             sound: String?,
                             contentAvailable: Bool? = nil,

--- a/Sources/FCM/FCMApnsConfig/FCMApnsApsObject.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsApsObject.swift
@@ -80,12 +80,12 @@ public struct FCMApnsApsObject: Codable, Equatable {
     }
     
     public init(alertString: String?,
-                            badge: Int? = nil,
-                            sound: String?,
-                            contentAvailable: Bool? = nil,
-                            category: String? = nil,
-                            threadId: String? = nil,
-                            mutableContent: Bool? = nil) {
+                badge: Int? = nil,
+                sound: String?,
+                contentAvailable: Bool? = nil,
+                category: String? = nil,
+                threadId: String? = nil,
+                mutableContent: Bool? = nil) {
         self.init(config: Config(alert: FCMApnsAlertOrString.fromRaw(alertString),
                                  badge: badge,
                                  sound: sound,
@@ -96,12 +96,12 @@ public struct FCMApnsApsObject: Codable, Equatable {
     }
     
     public init(alert: FCMApnsAlert? = nil,
-                            badge: Int? = nil,
-                            sound: String?,
-                            contentAvailable: Bool? = nil,
-                            category: String? = nil,
-                            threadId: String? = nil,
-                            mutableContent: Bool? = nil) {
+                badge: Int? = nil,
+                sound: String?,
+                contentAvailable: Bool? = nil,
+                category: String? = nil,
+                threadId: String? = nil,
+                mutableContent: Bool? = nil) {
         self.init(config: Config(alert: FCMApnsAlertOrString.fromRaw(alert),
                                  badge: badge,
                                  sound: sound,

--- a/Sources/FCM/FCMApnsConfig/FCMApnsPayload.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsPayload.swift
@@ -1,8 +1,8 @@
-/// Default APNS payload class
+/// Default APNS payload model
 /// it contains aps dictionary inside
 /// you can use your own custom payload class
 /// it just should conform to FCMApnsPayloadProtocol
-public class FCMApnsPayload: FCMApnsPayloadProtocol {
+public struct FCMApnsPayload: FCMApnsPayloadProtocol, Equatable {
     /// The APS object, primary alert
     public var aps: FCMApnsApsObject
 

--- a/Sources/FCM/FCMApnsConfig/FCMApnsPayloadProtocol.swift
+++ b/Sources/FCM/FCMApnsConfig/FCMApnsPayloadProtocol.swift
@@ -1,7 +1,7 @@
-/// Use it for your custom payload class
+/// Use it for your custom payload model
 ///
 /// Example code:
-///     class MyCustomPayload: FCMApnsPayloadProtocol {
+///     struct MyCustomPayload: FCMApnsPayloadProtocol {
 ///         var aps: FCMApnsApsObject
 ///         var myCustomKey: String
 ///
@@ -10,6 +10,6 @@
 ///             self.myCustomKey = myCustomKey
 ///         }
 ///     }
-public protocol FCMApnsPayloadProtocol: Codable {
+public protocol FCMApnsPayloadProtocol: Codable, Equatable {
     var aps: FCMApnsApsObject { get set }
 }


### PR DESCRIPTION
Sorry, it's me again 😬 

Should be the last PR I need for now. 🤞 

This one make the payload data models `Equatable`, again to ease tests. To do this, I had to convert some models from `class` to `struct` (`FCMApnsPayload` and `FCMApnsApsObject`). 

Is there a particular reason for using `class` here or it is simply a default choice?

I also renamed the `FCMApnsAlertOrString` to `asPayload`/`asMessage` as mentioned in the previous one.

Again, thanks very much for your quick reviews.