### PR TITLE
fixed decode token issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
     dependencies: [
         // 💧 A server-side Swift web framework.
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "https://github.com/vapor/jwt.git", from: "4.0.0-rc"),
+        .package(url: "https://github.com/vapor/jwt.git", from: "4.0.0"),
     ],
     targets: [
         .target(name: "FCM", dependencies: [

--- a/Sources/FCM/Helpers/FCM+AccessToken.swift
+++ b/Sources/FCM/Helpers/FCM+AccessToken.swift
@@ -19,7 +19,7 @@ extension FCM {
         .validate()
         .flatMapThrowing { res -> String in
             struct Result: Codable {
-                var access_token: String
+                let access_token: String
             }
 
             guard let body = res.body, let data = body.getData(at: body.readerIndex, length: body.readableBytes) else {

--- a/Sources/FCM/Helpers/FCM+AccessToken.swift
+++ b/Sources/FCM/Helpers/FCM+AccessToken.swift
@@ -21,7 +21,12 @@ extension FCM {
             struct Result: Codable {
                 var access_token: String
             }
-            let result = try res.content.decode(Result.self)
+
+            guard let body = res.body, let data = body.getData(at: body.readerIndex, length: body.readableBytes) else {
+                throw Abort(.notFound, reason: "Data not found")
+            }
+
+            let result = try JSONDecoder().decode(Result.self, from: data)
             return result.access_token
         }
     }

--- a/Sources/FCM/Helpers/FCM+AccessToken.swift
+++ b/Sources/FCM/Helpers/FCM+AccessToken.swift
@@ -22,12 +22,7 @@ extension FCM {
                 let access_token: String
             }
 
-            guard let body = res.body, let data = body.getData(at: body.readerIndex, length: body.readableBytes) else {
-                throw Abort(.notFound, reason: "Data not found")
-            }
-
-            let result = try JSONDecoder().decode(Result.self, from: data)
-            return result.access_token
+            return try res.content.decode(Result.self, using: JSONDecoder()).access_token
         }
     }
 }


### PR DESCRIPTION
Hey,

I found strange issue, with used `res.content.decode(Result.self)` access_token was not decoded (at the same time JSON body with access_token received) and in total it was impossible to send FCM message.

So, I replaced this call to decode access_token using JSON decoder and everything works well.