### PR TITLE
Removed unneeded setting of ignoreUncleanSSLShutdown to true

### DIFF
--- a/Sources/FCM/FCM.swift
+++ b/Sources/FCM/FCM.swift
@@ -35,9 +35,6 @@ public struct FCM {
     // MARK: Initialization
 
     init(application: Application, client: Client) {
-        if !application.http.client.configuration.ignoreUncleanSSLShutdown {
-            application.http.client.configuration.ignoreUncleanSSLShutdown = true
-        }
         self.application = application
         self.client = client
     }


### PR DESCRIPTION
As mentioned in #35, setting `ignoreUncleanSSLShutdown` to `true`, seems to not be necessary anymore. This PR removes the unnecessary piece of code.

Also setting it in this way had no effect, as the client of the application was accessed before configuring it. So this change should not really impact anyone, as all it did was resulting in a warning from Vapor. Removing the code, will also make sure the warning does not show up anymore.