### PR TITLE
Ignore server key and use OAuth instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,6 @@ So you could take a look on its source code to build proper message.
 
 # Batch sending
 
-### Preparation
-
-1. Go to [Firebase Console](https://console.firebase.google.com/) -> Project Settings -> Cloud Messaging tab
-2. Copy `Server Key` from `Project Credentials` area
-3. Put server key into environment variables as `FCM_SERVER_KEY=<YOUR_SERVER_KEY>` (or put it into `serviceAccountKey.json` file as `server_key`)
-
-### Sending
-
 ```swift
 // get it from iOS/Android SDK
 let token1 = "<YOUR FIREBASE DEVICE TOKEN>"
@@ -158,19 +150,13 @@ It is must have for developers who don't want to add Firebase libs into their ap
 
 ### Preparation
 
-1. Go to [Firebase Console](https://console.firebase.google.com/) -> Project Settings -> Cloud Messaging tab
-2. Copy `Server Key` from `Project Credentials` area
-
-Next steps are optional
-
-3. Put server key into environment variables as `FCM_SERVER_KEY=<YOUR_SERVER_KEY>` (or put it into `serviceAccountKey.json` file as `server_key`)
-4. Put your app bundle identifier into environment variables as `FCM_APP_BUNDLE_ID=<APP_BUNDLE_ID>`
+Put your app bundle identifier into environment variables as `FCM_APP_BUNDLE_ID=<APP_BUNDLE_ID>`.
 
 ### Tokens registration
 
 ```swift
 /// The simplest way
-/// .env here means that FCM_SERVER_KEY and FCM_APP_BUNDLE_ID will be used
+/// .env here means that FCM_APP_BUNDLE_ID will be used
 application.fcm.registerAPNS(.env, tokens: "token1", "token3", ..., "token100").flatMap { tokens in
     /// `tokens` is array of `APNSToFirebaseToken` structs
     /// which contains:
@@ -187,7 +173,6 @@ extension RegisterAPNSID {
 /// Advanced way
 application.fcm.registerAPNS(
     appBundleId: String, // iOS app bundle identifier
-    serverKey: String?, // optional server key, if nil then env variable will be used
     sandbox: Bool, // optional sandbox key, false by default
     tokens: [String], // an array of APNS tokens
     on: EventLoop? // optional event loop, if nil then application.eventLoopGroup.next() will be used

--- a/Sources/FCM/Helpers/FCM+CreateTopic.swift
+++ b/Sources/FCM/Helpers/FCM+CreateTopic.swift
@@ -22,14 +22,12 @@ extension FCM {
         guard let configuration = self.configuration else {
             fatalError("FCM not configured. Use app.fcm.configuration = ...")
         }
-        guard let serverKey = configuration.serverKey else {
-            fatalError("FCM: CreateTopic: Server Key is missing.")
-        }
         let url = self.iidURL + "batchAdd"
         let name = name ?? UUID().uuidString
         return getAccessToken().flatMap { accessToken -> EventLoopFuture<ClientResponse> in
             var headers = HTTPHeaders()
-            headers.add(name: .authorization, value: "key=\(serverKey)")
+            headers.bearerAuthorization = .init(token: accessToken)
+            headers.add(name: "access_token_auth", value: "true")
 
             return self.client.post(URI(string: url), headers: headers) { (req) in
                 struct Payload: Content {

--- a/Sources/FCM/Helpers/FCM+DeleteTopic.swift
+++ b/Sources/FCM/Helpers/FCM+DeleteTopic.swift
@@ -22,13 +22,11 @@ extension FCM {
         guard let configuration = self.configuration else {
             fatalError("FCM not configured. Use app.fcm.configuration = ...")
         }
-        guard let serverKey = configuration.serverKey else {
-            fatalError("FCM: DeleteTopic: Server Key is missing.")
-        }
         let url = self.iidURL + "batchRemove"
         return getAccessToken().flatMap { accessToken -> EventLoopFuture<ClientResponse> in
             var headers = HTTPHeaders()
-            headers.add(name: .authorization, value: "key=\(serverKey)")
+            headers.bearerAuthorization = .init(token: accessToken)
+            headers.add(name: "access_token_auth", value: "true")
 
             return self.client.post(URI(string: url), headers: headers) { (req) in
                 struct Payload: Content {

--- a/Sources/FCM/Helpers/FCM+GetTopics.swift
+++ b/Sources/FCM/Helpers/FCM+GetTopics.swift
@@ -6,13 +6,11 @@ extension FCM {
         guard let configuration = self.configuration else {
             fatalError("FCM not configured. Use app.fcm.configuration = ...")
         }
-        guard let serverKey = configuration.serverKey else {
-            fatalError("FCM: GetTopics: Server Key is missing.")
-        }
         let url = self.iidURL + "info/\(token)?details=true"
         return getAccessToken().flatMap { accessToken -> EventLoopFuture<ClientResponse> in
             var headers = HTTPHeaders()
-            headers.add(name: .authorization, value: "key=\(serverKey)")
+            headers.bearerAuthorization = .init(token: accessToken)
+            headers.add(name: "access_token_auth", value: "true")
 
             return self.client.get(URI(string: url), headers: headers)
         }

--- a/Sources/FCM/Helpers/FCM+RegisterAPNS.swift
+++ b/Sources/FCM/Helpers/FCM+RegisterAPNS.swift
@@ -106,22 +106,22 @@ extension FCM {
             return eventLoop.future([])
             #endif
         }
-        guard let serverKey = serverKey ?? configuration.serverKey else {
-            fatalError("FCM: Register APNS: Server Key is missing.")
-        }
         let url = iidURL + "batchImport"
 
-        var headers = HTTPHeaders()
-        headers.add(name: .authorization, value: "key=\(serverKey)")
+        return getAccessToken().flatMap { accessToken in
+            var headers = HTTPHeaders()
+            headers.bearerAuthorization = .init(token: accessToken)
+            headers.add(name: "access_token_auth", value: "true")
 
-        return self.client.post(URI(string: url), headers: headers) { (req) in
-            struct Payload: Content {
-                let application: String
-                let sandbox: Bool
-                let apns_tokens: [String]
+            return self.client.post(URI(string: url), headers: headers) { (req) in
+                struct Payload: Content {
+                    let application: String
+                    let sandbox: Bool
+                    let apns_tokens: [String]
+                }
+                let payload = Payload(application: appBundleId, sandbox: sandbox, apns_tokens: tokens)
+                try req.content.encode(payload)
             }
-            let payload = Payload(application: appBundleId, sandbox: sandbox, apns_tokens: tokens)
-            try req.content.encode(payload)
         }
         .validate()
         .flatMapThrowing { res in


### PR DESCRIPTION
Authenticating using server key is no longer supported.

This fixes #60 for v2.